### PR TITLE
Add SquirrelJME to adopters.csv

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -268,6 +268,7 @@ Spree, https://github.com/spree/spree
 Spring Boot, https://github.com/spring-projects/spring-boot
 Spring, https://github.com/spring-projects
 Squirrel for Windows, https://github.com/squirrel/squirrel.windows
+SquirrelJME, https://squirreljme.cc/
 Stack.io, https://github.com/germanstack
 Storybook, https://github.com/storybookjs/storybook
 Styled Hooks, https://github.com/colingourlay/styled-hooks


### PR DESCRIPTION
Hi!

This adds SquirrelJME, which uses the Contributor Code of Conduct: <https://squirreljme.cc/doc/tip/code-of-conduct.mkd>.